### PR TITLE
Persist documents, one per author per file per commit

### DIFF
--- a/open_script.rb
+++ b/open_script.rb
@@ -12,9 +12,7 @@ repo = Rugged::Repository.new(ARGV[0])
 project_name = repo.workdir.split("/").last
 
 # Instantiate DB and collection connection
-client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => "carry_your_weight")
-db = client.database
-collection = db[project_name]
+collection = Mongo::Client.new([ '127.0.0.1:27017' ], :database => "carry_your_weight")[project_name]
 
 # Get the HEAD commit from master
 master_head = repo.branches.find{|br| br.name == "master"}.target


### PR DESCRIPTION
Each document has the author, the lines that author write for this file,
full filepath, commit SHA, timestamp

These documents are added to a Mongo database named "carry_your_weight",
into a collection named after the git project being analyed.

Currently, the database must be local, and the names above are not
configurable. This work must be brought in before bringing to the web.

Fixes #1
